### PR TITLE
 - fix mosby crashes by reducing version to 2.0.1 from 3.x.x, where p…

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -161,8 +161,11 @@ dependencies {
     compile 'com.github.chrisbanes:PhotoView:2.0.0'
     compile 'de.hdodenhof:circleimageview:2.1.0'
     //mvp
-    compile 'com.hannesdorfmann.mosby3:mvp:3.0.4'
-    compile 'com.hannesdorfmann.mosby3:mvp-nullobject-presenter:3.0.4'
+    //WARNING!!!
+    //Do not update to 3+ version, as there are problems with caching presenters that are not singleton
+    //WARNING!!!
+    compile 'com.hannesdorfmann.mosby:mvp:2.0.1'
+//    compile 'com.hannesdorfmann.mosby3:mvp-nullobject-presenter:3.0.4'
     //vk
     compile 'com.vk:androidsdk:1.6.8'
     //facebook

--- a/core/src/main/java/ru/kuchanov/scpcore/manager/MyPreferenceManager.java
+++ b/core/src/main/java/ru/kuchanov/scpcore/manager/MyPreferenceManager.java
@@ -44,7 +44,7 @@ public class MyPreferenceManager implements MyPreferenceManagerModel {
     /**
      * used to calculate is it time to request new Interstitial ads (5 min)
      */
-    private static final long PERIOD_BEFORE_INTERSTITIAL_MUST_BE_SHOWN_IN_MILLIS = Period.minutes(5).toStandardDuration().getMillis();
+    private static final long PERIOD_BEFORE_INTERSTITIAL_MUST_BE_SHOWN_IN_MILLIS = Period.minutes(15).toStandardDuration().getMillis();
     /**
      * offer free trial every 7 days
      */

--- a/core/src/main/java/ru/kuchanov/scpcore/mvp/base/BaseMvp.java
+++ b/core/src/main/java/ru/kuchanov/scpcore/mvp/base/BaseMvp.java
@@ -2,8 +2,8 @@ package ru.kuchanov.scpcore.mvp.base;
 
 import android.support.annotation.StringRes;
 
-import com.hannesdorfmann.mosby3.mvp.MvpPresenter;
-import com.hannesdorfmann.mosby3.mvp.MvpView;
+import com.hannesdorfmann.mosby.mvp.MvpPresenter;
+import com.hannesdorfmann.mosby.mvp.MvpView;
 
 import ru.kuchanov.scpcore.Constants;
 import ru.kuchanov.scpcore.db.model.User;

--- a/core/src/main/java/ru/kuchanov/scpcore/mvp/base/BasePresenter.java
+++ b/core/src/main/java/ru/kuchanov/scpcore/mvp/base/BasePresenter.java
@@ -6,7 +6,7 @@ import android.support.v4.util.Pair;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
-import com.hannesdorfmann.mosby3.mvp.MvpNullObjectBasePresenter;
+import com.hannesdorfmann.mosby.mvp.MvpNullObjectBasePresenter;
 import com.vk.sdk.VKSdk;
 
 import ru.kuchanov.scpcore.BaseApplication;

--- a/core/src/main/java/ru/kuchanov/scpcore/ui/base/BaseActivity.java
+++ b/core/src/main/java/ru/kuchanov/scpcore/ui/base/BaseActivity.java
@@ -44,7 +44,7 @@ import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
-import com.hannesdorfmann.mosby3.mvp.MvpActivity;
+import com.hannesdorfmann.mosby.mvp.MvpActivity;
 import com.vk.sdk.VKAccessToken;
 import com.vk.sdk.VKCallback;
 import com.vk.sdk.VKScope;

--- a/core/src/main/java/ru/kuchanov/scpcore/ui/base/BaseFragment.java
+++ b/core/src/main/java/ru/kuchanov/scpcore/ui/base/BaseFragment.java
@@ -14,7 +14,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.hannesdorfmann.mosby3.mvp.MvpFragment;
+import com.hannesdorfmann.mosby.mvp.MvpFragment;
 import com.squareup.leakcanary.RefWatcher;
 
 import java.io.IOException;

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 
 #version of the core
-version=1.0.35
+version=1.0.36


### PR DESCRIPTION
…resenter cache added, which breaks dagger presenter injections (presenters that are not singleton)

 - increase load inrestital period to 15 min from 5.
 - increase version